### PR TITLE
Redirect unauthenticated users to landing page

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>KairoDex Dashboard</title>
+    <script>
+      // Ensure only logged-in users can access dashboard
+      const user = localStorage.getItem('user');
+      if (!user) {
+        window.location.replace('/kairodex.html');
+      } else {
+        // When user exists, append user identifier to URL if not already present
+        const pathParts = window.location.pathname.split('/');
+        if (pathParts.length < 3 || pathParts[2] !== encodeURIComponent(user)) {
+          window.location.replace(`/dashboard/${encodeURIComponent(user)}`);
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Welcome to your dashboard</h1>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>KairoDex Redirect</title>
+    <script>
+      // Redirect based on authentication status
+      const user = localStorage.getItem('user');
+      if (user) {
+        // Assume 'user' stores the username or identifier for dashboard routing
+        window.location.replace(`/dashboard/${encodeURIComponent(user)}`);
+      } else {
+        window.location.replace('/kairodex.html');
+      }
+    </script>
+  </head>
+  <body>
+    <!-- Redirecting... -->
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add `index.html` to route visitors to the landing page unless a stored user ID is present
- Add `dashboard/index.html` guard to ensure only authenticated visitors reach the dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba348cce788323abee75ce9c79439b