### PR TITLE
Enable sending generated emails through Resend

### DIFF
--- a/background.js
+++ b/background.js
@@ -336,6 +336,40 @@ class SupabaseManager {
   }
 }
 
+// Send email using Resend API
+async function sendEmailViaResend({ to, subject, body }) {
+  try {
+    const { resendApiKey } = await chrome.storage.local.get(['resendApiKey']);
+    if (!resendApiKey) {
+      throw new Error('Resend API key not configured');
+    }
+
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${resendApiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        from: 'no-reply@complyze.co',
+        to,
+        subject,
+        html: `<p>${body}</p>`
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText);
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error('Resend email error:', error);
+    return { success: false, error: error.message };
+  }
+}
+
 // Message handling for communication with content scripts
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   console.log('Background received message:', message);
@@ -373,7 +407,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         .then(result => sendResponse({ success: true, result }))
         .catch(error => sendResponse({ success: false, error: error.message }));
       return true;
-      
+
+    case 'SEND_EMAIL':
+      sendEmailViaResend(message)
+        .then(sendResponse)
+        .catch(error => sendResponse({ success: false, error: error.message }));
+      return true;
+
     default:
       console.warn('Unknown message type:', message.type);
       sendResponse({ success: false, error: 'Unknown message type' });

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
     "*://claude.ai/*",
     "*://gemini.google.com/*",
     "*://meta.ai/*",
-    "https://openrouter.ai/*"
+    "https://openrouter.ai/*",
+    "https://api.resend.com/*"
   ],
   "content_scripts": [
     {

--- a/popup.html
+++ b/popup.html
@@ -235,6 +235,46 @@
             font-size: 12px;
             margin-bottom: 10px;
         }
+
+        .email-modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        }
+
+        .email-modal-content {
+            background: #1e293b;
+            padding: 20px;
+            border-radius: 8px;
+            width: 100%;
+            max-width: 300px;
+        }
+
+        .email-modal-content input,
+        .email-modal-content textarea {
+            width: 100%;
+            margin-bottom: 10px;
+            padding: 8px;
+            border-radius: 4px;
+            border: none;
+        }
+
+        .email-modal-content textarea {
+            min-height: 80px;
+            resize: vertical;
+        }
+
+        .email-actions {
+            display: flex;
+            gap: 10px;
+        }
     </style>
 </head>
 <body>
@@ -320,14 +360,31 @@
         <!-- Actions -->
         <div class="actions-section">
             <div class="section-title">Quick Actions</div>
-            
+
             <button class="action-button" id="open-dashboard">
                 📊 Open Dashboard
             </button>
+
+            <button class="action-button" id="generate-email">
+                ✉️ Generate Email
+            </button>
         </div>
-        
+
         <!-- Messages -->
         <div id="message-container"></div>
+
+        <!-- Generate Email Modal -->
+        <div id="email-modal" class="email-modal" style="display: none;">
+            <div class="email-modal-content">
+                <h3 style="margin-bottom: 10px;">Generate Email</h3>
+                <input type="email" id="email-to" placeholder="Recipient">
+                <textarea id="email-body" placeholder="Message"></textarea>
+                <div class="email-actions">
+                    <button id="send-email" class="action-button" style="flex:1;">Send</button>
+                    <button id="cancel-email" class="action-button" style="flex:1;">Cancel</button>
+                </div>
+            </div>
+        </div>
     </div>
     
     <div class="footer">

--- a/popup.js
+++ b/popup.js
@@ -29,7 +29,45 @@ class PopupManager {
     document.getElementById('open-dashboard').addEventListener('click', () => {
       this.openDashboard();
     });
-    
+
+    const emailModal = document.getElementById('email-modal');
+    const openEmailBtn = document.getElementById('generate-email');
+    const sendEmailBtn = document.getElementById('send-email');
+    const cancelEmailBtn = document.getElementById('cancel-email');
+
+    if (openEmailBtn && emailModal && sendEmailBtn && cancelEmailBtn) {
+      openEmailBtn.addEventListener('click', () => {
+        emailModal.style.display = 'flex';
+      });
+
+      cancelEmailBtn.addEventListener('click', () => {
+        emailModal.style.display = 'none';
+      });
+
+      sendEmailBtn.addEventListener('click', async () => {
+        const to = document.getElementById('email-to').value;
+        const body = document.getElementById('email-body').value;
+        if (!to || !body) {
+          this.showMessage('Please complete all fields', 'error');
+          return;
+        }
+        const response = await chrome.runtime.sendMessage({
+          type: 'SEND_EMAIL',
+          to,
+          subject: 'Complyze Generated Email',
+          body
+        });
+        if (response && response.success) {
+          this.showMessage('Email sent', 'success');
+          emailModal.style.display = 'none';
+          document.getElementById('email-to').value = '';
+          document.getElementById('email-body').value = '';
+        } else {
+          this.showMessage('Failed to send email', 'error');
+        }
+      });
+    }
+
     console.log('Popup UI initialized');
   }
   


### PR DESCRIPTION
## Summary
- add Resend API host permission and background handler
- create Generate Email modal in popup with send and cancel buttons
- wire popup buttons to send emails via background script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c19165ab948323bba4dde822cd470d