### PR TITLE
fix: keep mobile chat visible above keyboard

### DIFF
--- a/debug_extension.html
+++ b/debug_extension.html
@@ -5,19 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Extension Debug - ChatGPT Simulator</title>
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-            margin: 0;
-            padding: 20px;
             background: #f7f7f8;
+            overflow: hidden;
         }
         .container {
             max-width: 800px;
             margin: 0 auto;
             background: white;
             border-radius: 12px;
-            overflow: hidden;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            height: 100%;
+            display: flex;
+            flex-direction: column;
         }
         .header {
             background: #10a37f;
@@ -27,12 +33,20 @@
         }
         .chat-area {
             padding: 20px;
-            min-height: 400px;
+            flex: 1;
+            overflow-y: auto;
         }
         .input-area {
             border-top: 1px solid #e5e5e5;
             padding: 20px;
             background: #f9f9f9;
+            position: fixed;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            max-width: 800px;
+            margin: 0 auto;
+            z-index: 10;
         }
         textarea {
             width: 100%;
@@ -229,6 +243,24 @@
                 alert('Sidebar not available. Make sure the extension is loaded.');
             }
         }
+
+        function adjustInputPosition() {
+            const inputArea = document.querySelector('.input-area');
+            const chatArea = document.querySelector('.chat-area');
+            if (!inputArea || !chatArea) return;
+            const vv = window.visualViewport;
+            const bottomOffset = vv ? window.innerHeight - vv.height - vv.offsetTop : 0;
+            inputArea.style.bottom = bottomOffset + 'px';
+            chatArea.style.paddingBottom = (inputArea.offsetHeight + bottomOffset) + 'px';
+        }
+
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', adjustInputPosition);
+            window.visualViewport.addEventListener('scroll', adjustInputPosition);
+        }
+        window.addEventListener('resize', adjustInputPosition);
+        window.addEventListener('load', adjustInputPosition);
+        adjustInputPosition();
 
         // Check status periodically
         setInterval(checkExtensionStatus, 2000);


### PR DESCRIPTION
## Summary
- keep debug chat input visible on mobile by anchoring input form to the bottom of the viewport
- dynamically offset chat input using `visualViewport` to avoid covering messages with the on-screen keyboard

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5672c60dc8323982b6017b1ba7d08